### PR TITLE
fix(totalenergies): exclude specific countries from locationSet

### DIFF
--- a/data/brands/shop/convenience.json
+++ b/data/brands/shop/convenience.json
@@ -5749,7 +5749,7 @@
       "id": "totalenergies-bd0db4",
       "locationSet": {
         "include": ["001"],
-        "exclude": ["us"]
+        "exclude": ["us", "id", "tr", "mx", "br", "de"]
       },
       "matchNames": [
         "total",


### PR DESCRIPTION
Extended Description:

This pull request updates the locationSet for the TotalEnergies brand entry. Specifically, it excludes Indonesia (id), Turkey (tr), Mexico (mx), Brazil (br), and Germany (de) from the locationSet.​

Reasoning:

In these countries, TotalEnergies operates primarily as fuel stations (amenity=fuel) rather than convenience stores (shop=convenience). This adjustment ensures that the NSI accurately reflects the brand's operations in these regions.​ IDN,TUR,MEX and BRA has Bonjour concenient stores.
TUR -
![image](https://github.com/user-attachments/assets/71e06f9c-efdb-4c5a-bf71-31660a3e9bce)


While DEU has Circle K
![image](https://github.com/user-attachments/assets/e3136927-edfc-438a-8d9a-6245896fa99d)

